### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/packages/infra/src/config/index.ts
+++ b/packages/infra/src/config/index.ts
@@ -24,7 +24,7 @@ else rootCfg.env = { account, region };
 export const config = rootCfg;
 
 if (process.env.CDK_CONFIG_SUPPRESS_WARNING == null && process.env.CDK_NAG == null) {
-  console.info(config);
+  console.info("CDK configuration loaded");
 }
 
 export default config;


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/machine-learning-operations-pipeline-for-recommendation-model/security/code-scanning/1](https://github.com/aws-samples/machine-learning-operations-pipeline-for-recommendation-model/security/code-scanning/1)

To fix the problem, avoid logging the entire `config` object directly, since it may contain sensitive data derived from environment variables or configuration files. Instead, either (a) remove the logging entirely, or (b) log only a minimal, non-sensitive subset (for example, just `account` and `region`, or even just that config loaded successfully). To avoid changing functionality in unexpected ways and to stay conservative with secrets, the safest minimal change is to stop logging `config` and replace it with a generic, non-sensitive message.

Concretely, in `packages/infra/src/config/index.ts`, replace `console.info(config);` on line 27 with a neutral informational message that does not include any configuration contents, such as `console.info("CDK configuration loaded");`. This preserves the “warning”/status behavior (something is logged when those environment flags are not set) without writing any potentially sensitive config data. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
